### PR TITLE
Integrated sbh to the neuroglancer special protocol system.

### DIFF
--- a/src/neuroglancer/util/http_path_completion.ts
+++ b/src/neuroglancer/util/http_path_completion.ts
@@ -88,6 +88,7 @@ const specialProtocolEmptyCompletions: CompletionWithDescription[] = [
     description: 'Google Cloud Storage (XML API) authenticated via ngauth'
   },
   {value: 's3://', description: 'Amazon Simple Storage Service (S3)'},
+  {value: 'sbh://', description: 'SBH storage system'},
   {value: 'https://'},
   {value: 'http://'},
 ];

--- a/src/neuroglancer/util/special_protocol_request.ts
+++ b/src/neuroglancer/util/special_protocol_request.ts
@@ -17,7 +17,7 @@
 import {CredentialsManager, MaybeOptionalCredentialsProvider} from 'neuroglancer/credentials_provider';
 import {fetchWithOAuth2Credentials} from 'neuroglancer/credentials_provider/oauth2';
 import {CancellationToken, uncancelableToken} from 'neuroglancer/util/cancellation';
-import {parseUrl, ResponseTransform} from 'neuroglancer/util/http_request';
+import {parseUrl, ResponseTransform, cancellableFetchOk} from 'neuroglancer/util/http_request';
 import {getRandomHexString} from 'neuroglancer/util/random';
 import {cancellableFetchS3Ok} from 'neuroglancer/util/s3';
 
@@ -89,6 +89,11 @@ export function parseSpecialUrl(url: string, credentialsManager: CredentialsMana
         credentialsProvider: undefined,
         url,
       };
+    case 'sbh':
+    return {
+      credentialsProvider: undefined,
+      url,
+    };
     default:
       return {
         credentialsProvider: undefined,
@@ -136,6 +141,21 @@ export async function cancellableFetchSpecialOk<T>(
           init, transformResponse, cancellationToken);
     case 's3':
       return cancellableFetchS3Ok(u.host, u.path, init, transformResponse, cancellationToken);
+    case 'sbh':
+
+    const token = 'xQSXUATcXC7L1sIdISzkwOsLRkPLVLZcYi3QiS9cjP';
+
+    const headers = new Headers();
+    headers.append('Authorization', `${token}`);
+
+    const requestOptions: RequestInit = {
+      method: 'GET', // Set your desired HTTP method
+      headers: headers,
+      ...init // Include other properties from the original init object
+    };
+    return await cancellableFetchOk(
+      `https://${u.host}${u.path}`, requestOptions, transformResponse,
+      cancellationToken); // CancellationToken = uncancelableToken
     default:
       return fetchWithOAuth2Credentials(
           credentialsProvider, url, init, transformResponse, cancellationToken);


### PR DESCRIPTION
Now we can fetch data through https by specifying our protocol. An example of a request:

zarr://sbh://127.0.0.1:8866/allen_average_template_10um_pir.zarr/allen_average_template_10um_pir.zarr/